### PR TITLE
Fix mostly broken youlag when freshrss is installed in subdirectory

### DIFF
--- a/extension.php
+++ b/extension.php
@@ -99,6 +99,7 @@ class YoulagExtension extends Minz_Extension
     $this->registerHook('nav_entries', array($this, 'setFeedThumbnailScreencapEnabled'), 20);
     $this->registerHook('nav_entries', array($this, 'setWatchLaterCategoryFilterEnabled'), 21);
     $this->registerHook('nav_entries', array($this, 'setUpdateCheckEnabled'), 22);
+    $this->registerHook('nav_entries', array($this, 'setBaseUrl'), 23);
     if (Minz_Request::paramString('get', '') === 's') {
       // Watch later page: add category filter
       $this->registerHook('nav_entries', array($this, 'createWatchLaterCategoryFilter'), 23);
@@ -330,6 +331,20 @@ class YoulagExtension extends Minz_Extension
   {
     $enabled = $this->yl_update_check_enabled ? 'true' : 'false';
     return '<div id="yl_update_check_enabled" data-yl-update-check-enabled="' . $enabled . '"></div>';
+  }
+
+  /**
+    * Pass the FreshRSS installation base URL
+    * The frontend js handles the behavior based on this the value in `data-base-url`.
+    *
+    * TODO: FreshRSS could supply this information to js directly so that this and other
+    * extensions do not have to do this.
+    * @return string
+    */
+  public function setBaseUrl(): string
+  {
+    $baseUrl = FreshRSS_Context::systemConf()->base_url;
+    return '<div id="yl_base_url" data-base-url="' . $baseUrl . '"></div>';
   }
 
   /**
@@ -649,9 +664,10 @@ class YoulagExtension extends Minz_Extension
   public function createFreshRssLogo(): string
   {
     $logoSrc = '../themes/icons/FreshRSS-logo.svg';
+    $linkUrl = Minz_Url::display('/i/');
     $html = <<<HTML
       <div id="yl_freshrss_logo_container">
-        <a href="/i/">
+        <a href="{$linkUrl}">
           <img id="yl_freshrss_logo" src="{$logoSrc}" alt="FreshRSS" loading="lazy" />
         </a>
       </div>

--- a/src/forms.js
+++ b/src/forms.js
@@ -88,7 +88,7 @@ function setAddFeedCategoryValue() {
 
   const page = getCurrentPage();
   const pathname = window.location.pathname;
-  if (page && pathname === '/i/' && page.url.includes('c=subscription') && page.url.includes('a=add')) {
+  if (page && pathname === `${app.frss.urlPrefix}/i/` && page.url.includes('c=subscription') && page.url.includes('a=add')) {
 
     const urlParams = new URLSearchParams(window.location.search);
     const categoryId = urlParams.get('yl_category_id');

--- a/src/global.js
+++ b/src/global.js
@@ -129,7 +129,8 @@ app.frss = {
     favoriteInactive: '../themes/Mapco/icons/non-starred.svg',
     favoriteActive: '../themes/Mapco/icons/starred.svg',
     chevronDown: '../themes/Mapco/icons/down.svg',
-  }
+  },
+  urlPrefix: getFreshRSSUrlPrefix()
 }
 
 app.types = {

--- a/src/helpers.js
+++ b/src/helpers.js
@@ -392,6 +392,22 @@ function isPageWhitelisted(whitelist, currentPageClass) {
   return false;
 }
 
+function getFreshRSSUrlPrefix() {
+  // Returns prefix that has to be appended to freshrss page urls. For example, if freshrss
+  // is installed at http://localhost/freshrss/, returns '/freshrss'. If it is installed at
+  // http://localhost/, returns ''.
+  // `setBaseUrl()` in `extension.php` outputs the user data to the DOM.
+
+  const el = document.querySelector('#yl_base_url');
+  if (!el) return '';
+
+  const data = el.getAttribute('data-base-url');
+  if (!data || data == '') return '';
+
+  const pathname = URL.parse(data).pathname;
+  return pathname.replace(/\/+$/, '');
+}
+
 function isVideoLabelsEnabled() {
   // Check if video platform label setting is enabled.
   // TODO: Refactor this once `Minz_HookType::JsVars` is implemented.

--- a/src/theme.scss
+++ b/src/theme.scss
@@ -1132,7 +1132,7 @@ nav.aside.aside_feed {
         display: block;
         width: 14px;
         height: 36px; /* For centering the icon vertically, actual icon size is determined by the width. */
-        background-image: url('../themes/Mapco/icons/view-normal.svg'); /* Existing image from FreshRSS theme "Mapco" */
+        background-image: url('./themes/Mapco/icons/view-normal.svg'); /* Existing image from FreshRSS theme "Mapco" */
         background-size: contain;
         background-position: center;
         background-repeat: no-repeat;
@@ -1431,7 +1431,7 @@ nav.nav_menu {
         content: "";
         width: 16px;
         height: 14px;
-        background-image: url("../themes/Mapco/icons/view-normal.svg");
+        background-image: url('./themes/Mapco/icons/view-normal.svg');
         background-size: contain;
         display: inline-block;
         filter: brightness(3);
@@ -4747,12 +4747,12 @@ body {
   min-width: 60px;
 
   &.youlag-favorited--false .youlag-favorited-icon {
-    background-image: url('../themes/Mapco/icons/non-starred.svg');
+    background-image: url('./themes/Mapco/icons/non-starred.svg');
     filter: brightness(1.6);
   }
-  
+
   &.youlag-favorited--true .youlag-favorited-icon {
-    background-image: url('../themes/Mapco/icons/starred.svg');
+    background-image: url('./themes/Mapco/icons/starred.svg');
     filter: brightness(1.5) sepia(1) hue-rotate(-25deg) saturate(4) contrast(1.2);
   }
 

--- a/src/ui.js
+++ b/src/ui.js
@@ -689,7 +689,7 @@ function renderToolbar() {
     // Create shortcut button to Youlag settings page.
     const settingsShortcut = document.createElement('div');
     settingsShortcut.id = 'yl_nav_menu_settings_shortcut';
-    settingsShortcut.innerHTML = `<a href="/i/?c=extension&a=configure&e=Youlag" class="btn" target="_blank" rel="noopener noreferrer">
+    settingsShortcut.innerHTML = `<a href="${app.frss.urlPrefix}/i/?c=extension&a=configure&e=Youlag" class="btn" target="_blank" rel="noopener noreferrer">
                                     More settings
                                   </a>`;
     menuContent.appendChild(settingsShortcut);
@@ -704,7 +704,7 @@ function renderToolbar() {
       if (page.id && /^f_\d+$/.test(page.id)) {
         manageFeed = Object.assign(document.createElement('a'), {
           id: 'yl_nav_menu_manage_current_feed',
-          href: `/i/?c=subscription&a=feed&id=${feedIdNumber}`,
+          href: `${app.frss.urlPrefix}/i/?c=subscription&a=feed&id=${feedIdNumber}`,
           target: '_blank',
           rel: 'noopener noreferrer',
           textContent: isVideoLabelsEnabled() && isLayoutVideo() ? 'Manage channel' : 'Manage feed'
@@ -903,7 +903,7 @@ function setMissingLogo() {
   const logo = document.createElement('div');
   logo.id = app.frss.id.logo;
   logo.innerHTML = `
-    <a href="/i/">
+    <a href="${app.frss.urlPrefix}/i/">
       <img id="${app.frss.id.logoImg}" src="../themes/icons/FreshRSS-logo.svg" alt="FreshRSS" loading="lazy">
     </a>
   `;

--- a/src/utilities.js
+++ b/src/utilities.js
@@ -148,7 +148,7 @@ function updateSidenavLinks() {
 
   if (isWatchLaterSortModified) {
     updateAnchorLink(
-      '/i/?a=normal&get=s&sort=lastUserModified&order=DESC',
+      `${app.frss.urlPrefix}/i/?a=normal&get=s&sort=lastUserModified&order=DESC`,
       document.querySelector('#aside_feed #sidebar .category.favorites > a')
     );
   }
@@ -164,7 +164,7 @@ function updateAddFeedLink() {
     const categoryIdSource = page.parentId || page.id;
     const categoryId = categoryIdSource && categoryIdSource.startsWith('c_') ? categoryIdSource.match(/^c_(\d+)$/) : null;
     updateAnchorLink(
-      `/i/?c=subscription&a=add&yl_category_id=${categoryId ? categoryId[1] : ''}`,
+      `${app.frss.urlPrefix}/i/?c=subscription&a=add&yl_category_id=${categoryId ? categoryId[1] : ''}`,
       document.querySelector('#btn-add')
     );
     return;
@@ -509,14 +509,14 @@ function getCurrentPage() {
 
   const routes = [
     {
-      path: '/i/',
+      path: app.frss.urlPrefix + '/i/',
       match: () => urlParams.get('a') === 'normal' && urlParams.has('search'),
       className: 'search_results',
       name: 'search_results',
       id: null,
     },
     {
-      path: '/i/',
+      path: app.frss.urlPrefix + '/i/',
       // Home page: no 'get' or 'c' param
       match: () => !urlParams.has('get') && !urlParams.has('c'),
       className: 'home',
@@ -524,35 +524,35 @@ function getCurrentPage() {
       id: null,
     },
     {
-      path: '/i/',
+      path: app.frss.urlPrefix + '/i/',
       match: () => urlParams.get('c') === 'extension',
       className: 'extension',
       name: 'extension',
       id: null,
     },
     {
-      path: '/i/',
+      path: app.frss.urlPrefix + '/i/',
       match: () => urlParams.get('get') === 'i',
       className: 'important',
       name: 'important',
       id: () => urlParams.get('get'),
     },
     {
-      path: '/i/',
+      path: app.frss.urlPrefix + '/i/',
       match: () => urlParams.get('get') === 's',
       className: 'watch_later',
       name: 'watch_later',
       id: () => urlParams.get('get'),
     },
     {
-      path: '/i/',
+      path: app.frss.urlPrefix + '/i/',
       match: () => urlParams.get('get') === 'T',
       className: 'playlists',
       name: 'playlists',
       id: () => urlParams.get('get'),
     },
     {
-      path: '/i/',
+      path: app.frss.urlPrefix + '/i/',
       match: () => /^t_\d+$/.test(urlParams.get('get') || ''),
       className: () => {
         const n = (urlParams.get('get') || '').substring(2);
@@ -562,7 +562,7 @@ function getCurrentPage() {
       id: () => urlParams.get('get'),
     },
     {
-      path: '/i/',
+      path: app.frss.urlPrefix + '/i/',
       // Category page: get param starts with c_
       match: () => urlParams.get('get') && urlParams.get('get').startsWith('c_'),
       className: () => {
@@ -573,7 +573,7 @@ function getCurrentPage() {
       id: () => urlParams.get('get'),
     },
     {
-      path: '/i/',
+      path: app.frss.urlPrefix + '/i/',
       match: () => (urlParams.get('get') && urlParams.get('get').startsWith('f_')),
       className: () => {
         const n = urlParams.get('get').substring(2);
@@ -757,7 +757,7 @@ async function fetchRelatedItems(category = 'watch_later', order = 'rand', limit
   }
 
   try {
-    const response = await fetch(`/i/?a=normal&${getParam}&sort=${order}`);
+    const response = await fetch(`${app.frss.urlPrefix}/i/?a=normal&${getParam}&sort=${order}`);
     if (!response.ok) {
       throw new Error('HTTP ' + response.status);
     }


### PR DESCRIPTION
I had FreshRSS installed in a subdirectory. I installed youlag, and I liked it. A while later, I was investigating why I never saw the YouTube video feed I saw in the screenshots and realized youlag was mostly broken as a result of not supporting the way I installed FreshRSS. This commit fixes it.

By the way, you caused a merge conflict with your changes during the few hours that I was working on my fix by removing a deprecated function that I had updated to fix the url it referenced! :D

I tested this on a normal install too where FreshRSS is not a subfolder, and caught a few regressions this change would have caused. Now, hopefully there are none :crossed_fingers:

By the way, if you know of some javascript variable that already stores the equivalent to `FreshRSS_Context::systemConf()->base_url`, then that would make these changes cleaner. I did quite a bit of looking but couldn't find any though. The `context.urls` variable is the closest thing I found. If I were to make a PR to FreshRSS to add that variable, I might add it there.